### PR TITLE
[kdy] 게시판/댓글 기능 수정 추가

### DIFF
--- a/groupware/src/main/java/com/mjc/groupware/board/controller/BoardController.java
+++ b/groupware/src/main/java/com/mjc/groupware/board/controller/BoardController.java
@@ -47,6 +47,8 @@ public class BoardController {
         model.addAttribute("boardDto", new BoardDto());
         return "board/create";
     }
+    
+    
     // 게시글 작성
     @PostMapping("/board")
     @ResponseBody
@@ -87,6 +89,8 @@ public class BoardController {
 
         return resultMap;
     }
+    
+    
     // 게시글 목록
     @GetMapping("/board/list")
     public String selectBoardAll(Model model, SearchDto searchDto, PageDto pageDto) {
@@ -99,7 +103,9 @@ public class BoardController {
 
         // 일반글 조회
         Page<Board> boardList = boardService.selectBoardAll(searchDto, pageDto);
+        
         pageDto.setTotalPage(boardList.getTotalPages());
+        pageDto.setTotalCount((int) boardList.getTotalElements()); // 추가: 전체 글 수 세팅
 
         model.addAttribute("boardList", boardList.getContent());
         model.addAttribute("searchDto", searchDto);
@@ -107,6 +113,7 @@ public class BoardController {
 
         return "board/list";
     }
+    
 
     @GetMapping("/board/detail/{boardNo}")
     public String selectBoardOne(@PathVariable("boardNo") Long boardNo, Model model) {
@@ -126,6 +133,7 @@ public class BoardController {
             return "error";
         }
     }
+    
 
     @GetMapping("/board/{id}/update")
     public String updateBoardView(@PathVariable("id") Long id, Model model) {
@@ -140,6 +148,8 @@ public class BoardController {
             return "error";
         }
     }
+    
+    
     // 게시글 수정
     @PostMapping("/board/{boardNo}/update")
     @ResponseBody
@@ -149,22 +159,34 @@ public class BoardController {
             @RequestParam(value = "files", required = false) List<MultipartFile> files,
             @RequestParam(value = "deleteFiles", required = false) List<Long> deleteFiles) {
         try {
+            // 게시글 번호 설정
             boardDto.setBoard_no(boardNo);
             boardDto.setDelete_files(deleteFiles);
+
+            // isFixed 값이 null이면 false로 설정 (체크박스를 해제한 경우)
+            if (boardDto.getIs_fixed() == null) {
+                boardDto.setIs_fixed(false); // 고정되지 않은 일반글로 설정
+            }
+
+            // 게시글 수정 서비스 호출
             boardService.updateBoard(boardDto, files);
 
+            // 성공 응답 반환
             Map<String, String> result = new HashMap<>();
             result.put("res_code", "200");
             result.put("res_msg", "수정 성공");
             result.put("boardNo", String.valueOf(boardNo));
             return ResponseEntity.ok(result);
         } catch (Exception e) {
+            // 에러 응답 반환
             Map<String, String> result = new HashMap<>();
             result.put("res_code", "500");
             result.put("res_msg", "에러: " + e.getMessage());
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(result);
         }
     }
+    
+    
     // 게시글 삭제
     @DeleteMapping("/board/delete/{boardNo}")
     @ResponseBody

--- a/groupware/src/main/java/com/mjc/groupware/board/repository/BoardRepository.java
+++ b/groupware/src/main/java/com/mjc/groupware/board/repository/BoardRepository.java
@@ -5,13 +5,13 @@ import java.util.Optional;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
-import org.springframework.transaction.annotation.Transactional;
 
 import com.mjc.groupware.board.entity.Board;
 
@@ -31,5 +31,7 @@ public interface BoardRepository extends JpaRepository<Board, Long>, JpaSpecific
 
     List<Board> findByIsFixedTrueOrderByRegDateDesc();  // 고정글만
     Page<Board> findByIsFixedFalse(Specification<Board> spec, Pageable pageable);  // 일반글만
+
+	List<Board> findByIsFixedTrueAndBoardStatusNot(String string, Sort by);
 
 }

--- a/groupware/src/main/java/com/mjc/groupware/board/service/BoardService.java
+++ b/groupware/src/main/java/com/mjc/groupware/board/service/BoardService.java
@@ -106,11 +106,9 @@ public class BoardService {
         repository.updateViews(boardNo);
     }
 
-    /**
-     * 게시글 목록 조회 (검색 및 페이징 포함)
-     */
+ // 게시글 목록 조회 (검색 및 페이징 포함)
     public Page<Board> selectBoardAll(SearchDto searchDto, PageDto pageDto) {
-        // 🔽 정렬 조건 설정
+        // 정렬 조건 설정
         Sort sort;
         if (searchDto.getOrder_type() == 1) { // 최신순
             sort = Sort.by(Sort.Direction.DESC, "regDate");
@@ -122,37 +120,35 @@ public class BoardService {
             sort = Sort.by(Sort.Direction.DESC, "regDate"); // 기본: 최신순
         }
 
-        // 🔽 페이징 처리
+        // 페이징 처리
         Pageable pageable = PageRequest.of(pageDto.getNowPage() - 1, pageDto.getNumPerPage(), sort);
 
-        // 🔽 기본 조건: 게시 상태 = 'N' && 고정글 아님
+        // 기본 조건: 게시 상태 = 'N'
         Specification<Board> spec = Specification.where(
-            (root, query, cb) -> cb.and(
-                cb.equal(root.get("boardStatus"), "N"),
-                cb.isFalse(root.get("isFixed"))
-            )
+            (root, query, cb) -> cb.equal(root.get("boardStatus"), "N")
         );
 
-        // 🔽 검색 조건
+        // 고정글 제외 여부 조건 추가 (필터 추가: `isFixed` == false)
+        spec = spec.and((root, query, cb) -> cb.isFalse(root.get("isFixed"))); // 고정글 제외
+
+        // 검색 조건
         String keyword = searchDto.getSearch_text();
         int searchType = searchDto.getSearch_type();
 
         if (keyword != null && !keyword.trim().isEmpty()) {
             switch (searchType) {
-            	
                 case 1: spec = spec.and(BoardSpecification.boardTitleContains(keyword)); break; // 제목 검색
                 case 2: spec = spec.and(BoardSpecification.boardContentContains(keyword)); break; // 내용 검색
                 case 3: spec = spec.and(BoardSpecification.boardTitleContains(keyword)
                             .or(BoardSpecification.boardContentContains(keyword))
-                    );
-                    break; // 제목+내용 검색
+            );
+            break; // 제목+내용 검색
             }
         }
 
-        // 🔽 최종 조회
+        // 최종 조회
         return repository.findAll(spec, pageable);
     }
-
     /**
      * 게시글 수정
      */

--- a/groupware/src/main/java/com/mjc/groupware/board/service/BoardService.java
+++ b/groupware/src/main/java/com/mjc/groupware/board/service/BoardService.java
@@ -128,10 +128,10 @@ public class BoardService {
             (root, query, cb) -> cb.equal(root.get("boardStatus"), "N")
         );
 
-        // 고정글 제외 여부 조건 추가 (필터 추가: `isFixed` == false)
-        spec = spec.and((root, query, cb) -> cb.isFalse(root.get("isFixed"))); // 고정글 제외
+        // 고정글 제외 조건: isFixed 필드를 명시적으로 검사하여 제외
+        spec = spec.and((root, query, cb) -> cb.isFalse(root.get("isFixed")));  // 고정글 제외
 
-        // 검색 조건
+        // 검색 조건 처리
         String keyword = searchDto.getSearch_text();
         int searchType = searchDto.getSearch_type();
 
@@ -141,8 +141,8 @@ public class BoardService {
                 case 2: spec = spec.and(BoardSpecification.boardContentContains(keyword)); break; // 내용 검색
                 case 3: spec = spec.and(BoardSpecification.boardTitleContains(keyword)
                             .or(BoardSpecification.boardContentContains(keyword))
-            );
-            break; // 제목+내용 검색
+                );
+                break; // 제목+내용 검색
             }
         }
 

--- a/groupware/src/main/java/com/mjc/groupware/board/service/BoardService.java
+++ b/groupware/src/main/java/com/mjc/groupware/board/service/BoardService.java
@@ -139,18 +139,13 @@ public class BoardService {
 
         if (keyword != null && !keyword.trim().isEmpty()) {
             switch (searchType) {
-                case 1:
-                    spec = spec.and(BoardSpecification.boardTitleContains(keyword));
-                    break;
-                case 2:
-                    spec = spec.and(BoardSpecification.boardContentContains(keyword));
-                    break;
-                case 3:
-                    spec = spec.and(
-                        BoardSpecification.boardTitleContains(keyword)
+            	
+                case 1: spec = spec.and(BoardSpecification.boardTitleContains(keyword)); break; // 제목 검색
+                case 2: spec = spec.and(BoardSpecification.boardContentContains(keyword)); break; // 내용 검색
+                case 3: spec = spec.and(BoardSpecification.boardTitleContains(keyword)
                             .or(BoardSpecification.boardContentContains(keyword))
                     );
-                    break;
+                    break; // 제목+내용 검색
             }
         }
 

--- a/groupware/src/main/java/com/mjc/groupware/board/service/BoardService.java
+++ b/groupware/src/main/java/com/mjc/groupware/board/service/BoardService.java
@@ -197,9 +197,14 @@ public class BoardService {
         board.setModDate(LocalDateTime.now());
 
         repository.save(board);
+
+        // 고정글 목록 갱신 (고정글에서 삭제된 게시글을 제외)
+        List<Board> fixedList = repository.findByIsFixedTrueOrderByRegDateDesc();
+        // fixedList에서 삭제된 boardNo를 제외하고 업데이트
+        fixedList.removeIf(fixedBoard -> fixedBoard.getBoardNo().equals(boardNo));
     }
-    
+    // 고정글 삭제를 하면 목록에서 삭제 될수있게 코드 수정
     public List<Board> selectFixedBoardList() {
-        return repository.findByIsFixedTrueOrderByRegDateDesc();
+        return repository.findByIsFixedTrueAndBoardStatusNot("Y", Sort.by(Sort.Order.desc("regDate")));
     }
 }

--- a/groupware/src/main/java/com/mjc/groupware/board/specification/BoardSpecification.java
+++ b/groupware/src/main/java/com/mjc/groupware/board/specification/BoardSpecification.java
@@ -6,7 +6,7 @@ import org.springframework.data.jpa.domain.Specification;
 
 public class BoardSpecification {
 
-    // 제목에 특정 문자열이 포함된 검색 조건
+	 // 제목에 특정 문자열이 포함된 검색 조건
     public static Specification<Board> boardTitleContains(String keyword) {
         return (root, query, criteriaBuilder) -> criteriaBuilder.like(root.get("boardTitle"), "%" + keyword + "%");
     }
@@ -15,13 +15,11 @@ public class BoardSpecification {
     public static Specification<Board> boardContentContains(String keyword) {
         return (root, query, criteriaBuilder) -> criteriaBuilder.like(root.get("boardContent"), "%" + keyword + "%");
     }
+
     // 게시글 삭제 여부 ("N" -> "Y")
     public static Specification<Board> notDeleted() {
         return (root, query, criteriaBuilder) ->
             criteriaBuilder.equal(root.get("boardStatus"), "N");
     }
-    public static Specification<Board> isFixed(boolean fixed) {
-        return (root, query, criteriaBuilder) ->
-            criteriaBuilder.equal(root.get("isFixed"), fixed);
-    }
+
 }

--- a/groupware/src/main/java/com/mjc/groupware/reply/controller/ReplyController.java
+++ b/groupware/src/main/java/com/mjc/groupware/reply/controller/ReplyController.java
@@ -45,6 +45,7 @@ public class ReplyController {
         Member member = getLoginMember();  // 로그인 사용자 정보 조회
         replyDto.setMember_no(member.getMemberNo());  // 댓글 작성자 설정
         replyDto.setBoard_no(boardNo);  // 댓글이 달릴 게시글 번호 설정
+        replyDto.setDeptName(member.getDept() != null ? member.getDept().getDeptName() : "부서 미정");  // 부서명 설정
 
         replyService.replyCreate(replyDto);  // 댓글 생성 서비스 호출
         return redirectToBoardDetail(boardNo);  // 상세 페이지로 리다이렉트
@@ -59,6 +60,7 @@ public class ReplyController {
         replyDto.setMember_no(member.getMemberNo());  // 대댓글 작성자 설정
         replyDto.setBoard_no(boardNo);  // 게시글 번호 설정
         replyDto.setParent_reply_no(parentReplyNo);  // 부모 댓글 번호 설정
+        replyDto.setDeptName(member.getDept() != null ? member.getDept().getDeptName() : "부서 미정");  // 부서명 설정
 
         replyService.replyCreateSub(replyDto);  // 대댓글 생성 서비스 호출
         return redirectToBoardDetail(boardNo);  // 상세 페이지로 리다이렉트

--- a/groupware/src/main/java/com/mjc/groupware/reply/dto/ReplyDto.java
+++ b/groupware/src/main/java/com/mjc/groupware/reply/dto/ReplyDto.java
@@ -36,6 +36,8 @@ public class ReplyDto {
     private List<ReplyDto> subReplies = new ArrayList<>();  // 대댓글 목록
 
     private Member member; // Member 객체 추가
+    
+    private int subReplyCount; // 대댓글 개수
 
     // [부서명]성명 형식으로 작성자 정보를 반환하는 메소드 추가
     public String getFormattedMemberInfo() {
@@ -60,7 +62,7 @@ public class ReplyDto {
      * Entity -> DTO 변환
      */
     public static ReplyDto toDto(Reply reply) {
-        return ReplyDto.builder()
+        ReplyDto dto = ReplyDto.builder()
                 .reply_no(reply.getReplyNo())
                 .member_no(reply.getMember() != null ? reply.getMember().getMemberNo() : null)
                 .memberName(reply.getMember() != null ? reply.getMember().getMemberName() : null)
@@ -75,7 +77,18 @@ public class ReplyDto {
                 .member(reply.getMember()) // Member 객체 설정
                 .memberPhoto(reply.getMember() != null && reply.getMember().getMemberAttachs() != null && !reply.getMember().getMemberAttachs().isEmpty() ? reply.getMember().getMemberAttachs().get(0).getAttachPath() : null)
                 .build();
+        
+        // 대댓글 수 초기화
+        dto.setSubReplyCount(0);
+        
+        return dto;
     }
+
+    // 대댓글 수 증가시키는 메소드
+    public void incrementSubReplyCount() {
+        this.subReplyCount++;
+    }
+
     // 년월일시간 추가
     private static String formatDate(LocalDateTime dateTime) {
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");

--- a/groupware/src/main/java/com/mjc/groupware/reply/dto/ReplyDto.java
+++ b/groupware/src/main/java/com/mjc/groupware/reply/dto/ReplyDto.java
@@ -1,6 +1,7 @@
 package com.mjc.groupware.reply.dto;
 
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -20,6 +21,7 @@ public class ReplyDto {
     private Long reply_no;
     private Long member_no;
     private String memberName;  // 작성자 이름 추가
+    private String deptName; // 부서명 추가
     private Long board_no;
     private Long parent_reply_no; // 대댓글
     private String reply_content;
@@ -30,11 +32,16 @@ public class ReplyDto {
     private String newContent;
     
     private String memberPhoto; // 작성자 프로필 이미지 URL(member 엔티티에도 있어서 가져와서 쓰는중)
-    
-    private String timeAgo; // 댓글 등록(작성자 => 몇시간전 등록)
-    
+    private String regDateFormatted; // 추가
     private List<ReplyDto> subReplies = new ArrayList<>();  // 대댓글 목록
-    
+
+    private Member member; // Member 객체 추가
+
+    // [부서명]성명 형식으로 작성자 정보를 반환하는 메소드 추가
+    public String getFormattedMemberInfo() {
+        return String.format("[%s]%s", deptName != null ? deptName : "부서 미정", memberName);
+    }
+
     /**
      * DTO -> Entity 변환
      */
@@ -48,6 +55,7 @@ public class ReplyDto {
                 .parentReply(parent_reply_no != null ? Reply.builder().replyNo(parent_reply_no).build() : null)
                 .build();
     }
+
     /**
      * Entity -> DTO 변환
      */
@@ -55,16 +63,22 @@ public class ReplyDto {
         return ReplyDto.builder()
                 .reply_no(reply.getReplyNo())
                 .member_no(reply.getMember() != null ? reply.getMember().getMemberNo() : null)
-                .memberName(reply.getMember() != null ? reply.getMember().getMemberName() : null)  // 작성자 이름 추가
+                .memberName(reply.getMember() != null ? reply.getMember().getMemberName() : null)
+                .deptName(reply.getMember() != null && reply.getMember().getDept() != null ? reply.getMember().getDept().getDeptName() : null) // 부서명 설정
                 .board_no(reply.getBoard() != null ? reply.getBoard().getBoardNo() : null)
                 .parent_reply_no(reply.getParentReply() != null ? reply.getParentReply().getReplyNo() : null)
                 .reply_content(reply.getReplyContent())
                 .reply_status(reply.getReplyStatus())
                 .reg_date(reply.getRegDate())
                 .mod_date(reply.getModDate())
+                .regDateFormatted(reply.getRegDate() != null ? formatDate(reply.getRegDate()) : null)
+                .member(reply.getMember()) // Member 객체 설정
+                .memberPhoto(reply.getMember() != null && reply.getMember().getMemberAttachs() != null && !reply.getMember().getMemberAttachs().isEmpty() ? reply.getMember().getMemberAttachs().get(0).getAttachPath() : null)
                 .build();
     }
-
-	public ReplyDto(Reply reply) {
-	}
+    // 년월일시간 추가
+    private static String formatDate(LocalDateTime dateTime) {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
+        return dateTime.format(formatter);
+    }
 }

--- a/groupware/src/main/java/com/mjc/groupware/reply/entity/Reply.java
+++ b/groupware/src/main/java/com/mjc/groupware/reply/entity/Reply.java
@@ -74,36 +74,4 @@ public class Reply {
     @OneToMany(mappedBy = "parentReply", cascade = CascadeType.ALL)
     private List<Reply> childReplies = new ArrayList<>();
     
-    // 댓글 작성 시간을 상대적인 시간으로 변환하는 메서드
-    public String getTimeAgo() {
-        Duration duration = Duration.between(regDate, LocalDateTime.now());
-
-        long seconds = duration.getSeconds();
-        if (seconds < 60) {
-            return seconds + "초 전";
-        }
-        
-        long minutes = duration.toMinutes();
-        if (minutes < 60) {
-            return minutes + "분 전";
-        }
-        
-        long hours = duration.toHours();
-        if (hours < 24) {
-            return hours + "시간 전";
-        }
-        
-        long days = duration.toDays();
-        if (days < 30) {
-            return days + "일 전";
-        }
-        
-        long months = days / 30;
-        if (months < 12) {
-            return months + "개월 전";
-        }
-        
-        long years = days / 365;
-        return years + "년 전";
-    }
 }

--- a/groupware/src/main/java/com/mjc/groupware/reply/repository/ReplyRepository.java
+++ b/groupware/src/main/java/com/mjc/groupware/reply/repository/ReplyRepository.java
@@ -3,9 +3,17 @@ package com.mjc.groupware.reply.repository;
 import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.mjc.groupware.reply.entity.Reply;
 
 public interface ReplyRepository extends JpaRepository<Reply, Long> {
-    List<Reply> findByBoard_BoardNoAndReplyStatus(Long boardNo, String replyStatus);
+    
+    // 기존 메서드
+    List<Reply> findByBoard_BoardNoAndReplyStatus(Long boardNo, String replyStatus);  
+
+    // 새로 추가하는 fetch join 메서드
+    @Query("SELECT r FROM Reply r JOIN FETCH r.member WHERE r.board.boardNo = :boardNo AND r.replyStatus = :replyStatus")
+    List<Reply> findByBoardNoWithMember(@Param("boardNo") Long boardNo, @Param("replyStatus") String replyStatus);
 }

--- a/groupware/src/main/java/com/mjc/groupware/reply/service/ReplyService.java
+++ b/groupware/src/main/java/com/mjc/groupware/reply/service/ReplyService.java
@@ -68,6 +68,7 @@ public class ReplyService {
         replyRepository.save(subReply);
     }
 
+
     // 댓글 트리 구조 반환
     @Transactional(readOnly = true)
     public List<ReplyDto> getReplyListByBoard(Long boardNo) {
@@ -86,7 +87,8 @@ public class ReplyService {
             } else {
                 ReplyDto parentDto = replyMap.get(dto.getParent_reply_no());
                 if (parentDto != null) {
-                    parentDto.getSubReplies().add(dto); // 대댓글
+                    parentDto.getSubReplies().add(dto); // 대댓글 추가
+                    parentDto.setSubReplyCount(parentDto.getSubReplyCount() + 1); // 여기 추가!!
                 }
             }
         }

--- a/groupware/src/main/java/com/mjc/groupware/reply/service/ReplyService.java
+++ b/groupware/src/main/java/com/mjc/groupware/reply/service/ReplyService.java
@@ -1,6 +1,5 @@
 package com.mjc.groupware.reply.service;
 
-import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.*;
 
@@ -71,30 +70,23 @@ public class ReplyService {
 
     // 댓글 트리 구조 반환
     @Transactional(readOnly = true)
-    public List<ReplyDto> getRepliesByBoard(Long boardNo) {
+    public List<ReplyDto> getReplyListByBoard(Long boardNo) {
         List<Reply> replies = replyRepository.findByBoard_BoardNoAndReplyStatus(boardNo, "N");
 
-        Map<Long, ReplyDto> replyMap = new HashMap<>();
+        // 대댓글을 트리 구조로 정리
+        Map<Long, ReplyDto> replyMap = new LinkedHashMap<>();
         List<ReplyDto> result = new ArrayList<>();
 
         for (Reply reply : replies) {
             ReplyDto dto = ReplyDto.toDto(reply);
-            dto.setTimeAgo(getTimeAgo(dto.getReg_date()));
-
             replyMap.put(dto.getReply_no(), dto);
 
             if (dto.getParent_reply_no() == null) {
-                result.add(dto);
-            }
-        }
-
-        for (Reply reply : replies) {
-            if (reply.getParentReply() != null) {
-                ReplyDto parentDto = replyMap.get(reply.getParentReply().getReplyNo());
+                result.add(dto); // 댓글
+            } else {
+                ReplyDto parentDto = replyMap.get(dto.getParent_reply_no());
                 if (parentDto != null) {
-                    ReplyDto childDto = ReplyDto.toDto(reply);
-                    childDto.setTimeAgo(getTimeAgo(childDto.getReg_date())); // 재귀 함수 사용
-                    parentDto.getSubReplies().add(childDto);
+                    parentDto.getSubReplies().add(dto); // 대댓글
                 }
             }
         }
@@ -102,17 +94,20 @@ public class ReplyService {
         return result;
     }
     
- // 댓글 수정
+    
+    // 수정
     @Transactional
-    public void updateReply(ReplyDto replyDto, Member member) {
-        Reply reply = replyRepository.findById(replyDto.getReply_no())
-            .orElseThrow(() -> new RuntimeException("댓글을 찾을 수 없습니다."));
+    public void updateReply(ReplyDto dto, Member member) {
+        Reply reply = replyRepository.findById(dto.getReply_no())
+            .orElseThrow(() -> new IllegalArgumentException("댓글이 존재하지 않습니다."));
 
-        reply.setReplyContent(replyDto.getReply_content());
-        reply.setModDate(LocalDateTime.now());
-        replyRepository.save(reply);
+        if (!reply.getMember().getMemberNo().equals(member.getMemberNo())) {
+            throw new IllegalArgumentException("작성자만 수정할 수 있습니다.");
+        }
+
+        reply.setReplyContent(dto.getReply_content());
+        reply.setModDate(LocalDateTime.now()); // 명시적 수정일자 설정 (optional)
     }
-
     
 
 	/** 컨트롤러에 최신 내용을 돌려줄 때 사용 */
@@ -124,21 +119,20 @@ public class ReplyService {
     }
     
 
-    // 댓글 삭제 (Soft delete)
+ // 현재 삭제 시 자식까지 삭제되는 CascadeType.ALL만 설정
+ // 논리 삭제에서도 자식 댓글도 함께 처리하도록 하면 더 안전
     @Transactional
     public void replyDelete(Long replyNo, Long memberNo) {
         Reply reply = replyRepository.findById(replyNo)
-                .orElseThrow(() -> new IllegalArgumentException("댓글을 찾을 수 없습니다."));
+                .orElseThrow(() -> new IllegalArgumentException("해당 댓글이 존재하지 않습니다."));
 
-        if (!reply.getMember().getMemberNo().equals(memberNo)) {
-            throw new IllegalStateException("본인의 댓글만 삭제할 수 있습니다.");
+        if (!Objects.equals(reply.getMember().getMemberNo(), memberNo)) {
+            throw new SecurityException("작성자만 삭제할 수 있습니다.");
         }
 
-        reply.setReplyStatus("Y"); // 'Y' = 삭제됨
-        reply.setModDate(LocalDateTime.now());
-
-        replyRepository.save(reply);
+        reply.setReplyStatus("Y");
     }
+
     
 
     // 계층형 구조로 댓글 반환
@@ -150,7 +144,7 @@ public class ReplyService {
 
         for (Reply reply : replies) {
             ReplyDto dto = ReplyDto.toDto(reply);
-            dto.setTimeAgo(getTimeAgo(dto.getReg_date())); // 재귀 함수
+            //dto.setTimeAgo(getTimeAgo(dto.getReg_date())); // 재귀 함수
 
             if (dto.getParent_reply_no() == null) {
                 parentReplies.add(dto);
@@ -169,15 +163,6 @@ public class ReplyService {
         return parentReplies;
     }
 
-    // 시간 경과 계산(사용자가 댓글 달았을때 시간 반영해줌)
-    private String getTimeAgo(LocalDateTime time) {
-        Duration duration = Duration.between(time, LocalDateTime.now());
-        long minutes = duration.toMinutes();
-
-        if (minutes < 1) return "방금 전";
-        if (minutes < 60) return minutes + "분 전";
-        if (minutes < 1440) return (duration.toHours()) + "시간 전";
-        return duration.toDays() + "일 전";
-    }
+    
 
 }

--- a/groupware/src/main/java/com/mjc/groupware/report/dto/ReportDto.java
+++ b/groupware/src/main/java/com/mjc/groupware/report/dto/ReportDto.java
@@ -1,5 +1,31 @@
 package com.mjc.groupware.report.dto;
 
-public class ReportDto {
+import java.time.LocalDateTime;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@ToString
+public class ReportDto {
+	
+	private Long report_no; // 신고번호(ID)
+	private Long reporter_no; // 신고한 사용자
+	private Long reported_member_no; // 신고 대상 사용자
+	private String target_type; // 신고 대상 유형
+	private Long target_no; // 신고 대상(ID)
+	private String report_reason; // 신고 사유
+	private String report_detail; // 신고 상세 내용
+	private String is_processed; // 처리여부(Y/N)
+	private Long processed_no; // 처리 관리자
+	private LocalDateTime processed_date; // 처리일
+	private LocalDateTime report_date; // 신고일
 }

--- a/groupware/src/main/java/com/mjc/groupware/report/entity/Report.java
+++ b/groupware/src/main/java/com/mjc/groupware/report/entity/Report.java
@@ -1,5 +1,67 @@
 package com.mjc.groupware.report.entity;
 
-public class Report {
+import java.time.LocalDateTime;
 
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+@Builder
+@Table(name = "report")
+public class Report {
+	
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "report_no")
+	private Long reportNo; // 신고 번호(ID)
+	
+	@Column(name = "reporter_no")
+	private Long reporterNo; // 신고한 사용자
+	
+	@Column(name = "reported_member_no")
+	private Long reportedMemberNo; // 신고 대상 사용자
+	
+	@Column(name = "target_type")
+	private String targetType; // 신고 대상 유형
+	
+	@Column(name = "target_no")
+	private Long targetNo; // 신고 대상(ID)
+	
+	@Column(name = "report_reason")
+	private String reportReason; // 신고 사유
+	
+	@Column(name = "report_detail")
+	private String reportDetail; // 신고 상세 내용
+	
+	@Column(name = "is_processed")
+	private String isProcessed; // 처리 여부(Y/N)
+	
+	@Column(name = "processed_no")
+	private Long processedNo; // 처리 관리자
+	
+	@CreationTimestamp
+	@Column(name = "processed_date")
+	private LocalDateTime processedDate; // 처리일
+	
+	@UpdateTimestamp
+	@Column(name = "report_date")
+	private LocalDateTime reportDate; // 신고일
+	
+	
 }

--- a/groupware/src/main/resources/static/css/kdy.css
+++ b/groupware/src/main/resources/static/css/kdy.css
@@ -1,91 +1,122 @@
 @charset "UTF-8";
+
+/* 테이블 셀 색상 */
 .table td {
-		color: black !important;
-	}
- #start-editor img {
-            max-width: 50%;
-            height: auto;
-            display: block;
-            margin: 0 auto;
-        }
-
-        .file-link {
-            display: inline-block;
-            color: #007bff;
-            font-weight: 500;
-            text-decoration: none;
-            cursor: pointer;
-            transition: all 0.2s ease-in-out;
-        }
-        
-
-        .file-link:hover {
-            color: #000;
-            text-decoration: underline;
-        }
-
-        .file-preview img {
-            margin-top: 10px;
-            max-width: 200px;
-            height: auto;
-            display: block;
-        }
-
-       
-        .toastui-editor-contents img {
-    		max-width: 100%;
-    		height: auto;
-    		display: block;
- 
-		}
-
-		.toastui-editor-contents{
-	 		color: black !important;
-		}
-		
-		/* 고정된 게시글에 적용될 스타일 */
-		.fixed-row td {
-  			background-color: #f3e5f5 !important;  /* 연보라 */
-  			color: black !important;
-  			font-weight: bold;
-		}
-		.fixed-row {
-  			background-color: #e8d9ff !important;
-  			color: black !important;
-		}
-		
-		/* 댓글 작성 영역 */
-.comment-write {
-    position: sticky;
-    top: 75px; /* 네비바 높이만큼 띄우기 */
-    z-index: 1000;
-    background-color: #ffffff;
-    border-radius: 1rem;
-    padding: 1.5rem;
-    box-shadow: 0 0.125rem 0.25rem rgba(0, 0, 0, 0.075);
-    margin-bottom: 1.5rem;
+    color: black !important;
 }
 
-.comment-write label {
-    font-weight: 700;
-    font-size: 1.25rem;
-    margin-bottom: 1rem;
+/* 에디터 이미지 크기 */
+#start-editor img {
+    max-width: 50%;
+    height: auto;
+    display: block;
+    margin: 0 auto;
+}
+
+/* 파일 링크 스타일 */
+.file-link {
+    display: inline-block;
+    color: #007bff;
+    font-weight: 500;
+    text-decoration: none;
+    cursor: pointer;
+    transition: all 0.2s ease-in-out;
+}
+
+.file-link:hover {
+    color: #000;
+    text-decoration: underline;
+}
+
+/* 파일 미리보기 이미지 스타일 */
+.file-preview img {
+    margin-top: 10px;
+    max-width: 200px;
+    height: auto;
     display: block;
 }
 
+/* 에디터 이미지 크기 */
+.toastui-editor-contents img {
+    max-width: 100%;
+    height: auto;
+    display: block;
+}
+
+.toastui-editor-contents {
+    color: black !important;
+}
+
+/* 고정된 게시글 스타일 */
+.fixed-row td {
+    background-color: #f3e5f5 !important;  /* 연보라 */
+    color: black !important;
+    font-weight: bold;
+}
+
+.fixed-row {
+    background-color: #e8d9ff !important;
+    color: black !important;
+}
+
+/* 댓글 목록이 스크롤될 때 댓글 작성 영역이 겹치지 않도록 아래 여백 추가 */
+.reply-item:last-child {
+    padding-bottom: 130px; /* 댓글 작성 영역이 덮지 않도록 충분한 여백을 확보 */
+}
+
+/* 댓글 작성 영역 고정 */
+.comment-write {
+    position: fixed;
+    bottom: 0;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 90%;
+    max-width: 1260px;
+    padding: 20px;
+    background-color: white;
+    box-shadow: 0px -2px 10px rgba(0, 0, 0, 0.1);
+    z-index: 9999;
+    border-radius: 8px;
+    border: 1px solid #ddd;
+}
+
+
+/* 댓글 작성 영역의 레이블 */
+.comment-write label {
+    font-weight: 700;
+    font-size: 1.1rem;
+    margin-bottom: 0.5rem;
+    display: block;
+}
+
+/* 댓글 작성 텍스트 영역 */
 .comment-write textarea {
     resize: none;
-    height: 60px;
-    flex-grow: 1;
+    height: 60px; /* 높이를 설정하여 댓글 입력창처럼 만듬 */
+    width: 100%; /* 가로 크기를 100%로 맞춤 */
     border: 1px solid #ced4da;
     border-radius: 0.375rem;
     padding: 0.5rem;
     font-size: 1rem;
 }
 
+/* 댓글 작성 버튼 */
 .comment-write button {
     min-width: 80px;
-    height: 60px;
+    height: 40px; /* 버튼 크기 맞춤 */
+    font-size: 1rem;
+    margin-top: 10px;
+}
+
+/* 로그인 후 댓글 작성 안내 메시지 */
+.comment-write .text-muted {
+    font-size: 0.875rem;
+    margin-top: 10px;
+}
+
+/* 페이지 컨텐츠 영역 */
+body {
+    padding-bottom: 100px; /* 댓글 작성 영역을 고려한 여백 추가 */
 }
 
 /* 댓글 아이템 */
@@ -113,193 +144,22 @@
     flex-shrink: 0;
 }
 
-/* 댓글 상단 정보 */
-.reply-item > div.d-flex.align-items-start > div.flex-grow-1 > div.d-flex.justify-content-between {
-    align-items: center;
-}
-
-.reply-author strong {
-    font-weight: 700;
-    color: #212529;
-}
-
-.reply-author small.text-muted {
-    margin-left: 0.5rem;
-    color: #6c757d;
-    font-size: 0.875rem;
-}
-
-/* 버튼 그룹 */
-.reply-actions button,
-.reply-actions > button {
-    min-width: 60px;
-    font-size: 0.85rem;
-    padding: 0.25rem 0.75rem;
-    border-radius: 0.375rem;
-}
-
-/* 버튼 색상 */
-.btn-outline-primary {
-    color: #0d6efd;
-    border-color: #0d6efd;
-}
-
-.btn-outline-primary:hover {
-    background-color: #0d6efd;
-    color: #fff;
-    border-color: #0d6efd;
-}
-
-.btn-outline-danger {
-    color: #dc3545;
-    border-color: #dc3545;
-}
-
-.btn-outline-danger:hover {
-    background-color: #dc3545;
-    color: #fff;
-    border-color: #dc3545;
-}
-
-.btn-outline-secondary {
-    color: #6c757d;
-    border-color: #6c757d;
-}
-
-.btn-outline-secondary:hover {
-    background-color: #6c757d;
-    color: #fff;
-    border-color: #6c757d;
-}
-
-/* 댓글 내용 */
-.reply-content {
-    margin-top: 0.5rem;
-    margin-bottom: 0.75rem;
-    font-size: 1rem;
-    white-space: pre-line;
-    color: #343a40;
-}
-
-/* 수정 폼 */
-#reply-edit-form textarea {
-    resize: none;
-    height: 60px;
-    border: 1px solid #ced4da;
-    border-radius: 0.375rem;
-    padding: 0.5rem;
-    font-size: 1rem;
-    margin-bottom: 0.5rem;
-}
-
-#reply-edit-form .btn {
-    min-width: 60px;
-}
-
-/* 답글 버튼 */
-.reply-item > div > div > div.mb-2 > button.btn-sm {
-    font-size: 0.85rem;
-    padding: 0.25rem 0.75rem;
-}
-
-/* 대댓글 리스트 */
-.sub-reply-list {
+/* 답글 작성 폼 */
+.reply-form {
     margin-top: 1rem;
-    padding-left: 1rem;
-    border-left: 3px solid #dee2e6;
+}
+
+.reply-edit-form {
+    display: none;
 }
 
 .sub-reply-item {
-    background-color: #f8f9fa;
-    border-radius: 0.375rem;
-    padding: 0.75rem 1rem;
-    border: 1px solid #ccc;
+    background-color: #f1f3f5;
+    border-radius: 0.5rem;
+    padding: 1rem 1.25rem;
     margin-bottom: 0.75rem;
-    position: relative;
 }
 
-/* 대댓글 프로필 아이콘 */
-.sub-reply-item .profile-icon {
-    width: 30px;
-    height: 30px;
-    font-size: 1rem;
+.sub-reply-list {
+    padding-left: 30px; /* 대댓글을 조금 들여서 보여주기 */
 }
-
-/* 대댓글 상단 정보 */
-.sub-reply-item div.d-flex.align-items-start > div.flex-grow-1 > div.d-flex.justify-content-between {
-    align-items: center;
-}
-
-.sub-reply-item strong {
-    font-weight: 700;
-    color: #212529;
-}
-
-.sub-reply-item small.text-muted {
-    margin-left: 0.5rem;
-    color: #6c757d;
-    font-size: 0.8rem;
-}
-
-/* 대댓글 내용 */
-.sub-reply-item .reply-content {
-    margin-top: 0.4rem;
-    margin-bottom: 0.5rem;
-    font-size: 0.95rem;
-    white-space: pre-line;
-    color: #495057;
-}
-
-/* 대댓글 수정 폼 */
-.sub-reply-item #reply-edit-form textarea {
-    resize: none;
-    height: 50px;
-    border: 1px solid #ced4da;
-    border-radius: 0.375rem;
-    padding: 0.5rem;
-    font-size: 0.9rem;
-    margin-bottom: 0.5rem;
-}
-
-/* 대댓글 수정 버튼 */
-.sub-reply-item #reply-edit-form .btn {
-    min-width: 60px;
-    font-size: 0.85rem;
-}
-
-/* 댓글 폼, 대댓글 폼 공통 */
-.reply-form {
-    margin-top: 0.75rem;
-}
-
-.reply-form textarea {
-    resize: none;
-    height: 60px;
-    border: 1px solid #ced4da;
-    border-radius: 0.375rem;
-    padding: 0.5rem;
-    font-size: 1rem;
-}
-
-.reply-form button {
-    min-width: 80px;
-    font-size: 1rem;
-}
-
-/* 반응형: 작은 화면에서 댓글/대댓글 프로필 아이콘 크기 조정 */
-@media (max-width: 576px) {
-    .profile-icon {
-        width: 32px;
-        height: 32px;
-        font-size: 1rem;
-    }
-    
-    .sub-reply-item .profile-icon {
-        width: 24px;
-        height: 24px;
-        font-size: 0.85rem;
-    }
-}
-
-
-  

--- a/groupware/src/main/resources/static/css/kdy.css
+++ b/groupware/src/main/resources/static/css/kdy.css
@@ -300,13 +300,6 @@
         font-size: 0.85rem;
     }
 }
-.scroll-to-top-icon {
-    color: #0d6efd; /* Bootstrap primary color */
-    transition: color 0.3s ease;
-}
 
-.scroll-to-top-icon:hover {
-    color: #0a58ca;
-}
 
   

--- a/groupware/src/main/resources/templates/board/detail.html
+++ b/groupware/src/main/resources/templates/board/detail.html
@@ -112,6 +112,7 @@
     </th:block>
 </div>
 
+
 <!-- 댓글 + 대댓글 리스트 -->
 <div th:each="reply : ${replyList}" class="reply-item mb-3 p-3 border rounded-3">
     <div class="d-flex align-items-start mb-2">
@@ -206,7 +207,7 @@
 </div>
  <!-- 댓글 리스트 반복문 끝난 후 -->
 <div class="scroll-to-top-wrapper text-center my-4">
-    <i class="bi bi-arrow-bar-up scroll-to-top-icon" style="font-size: 2rem; cursor: pointer;" title="맨 위로 이동"></i>
+    <i class="bi bi-arrow-up-circle" style="font-size: 2rem; cursor: pointer;" title="맨 위로 이동"></i>
 </div>
             
 <!-- 삭제 JS 및 대댓글 폼 표시 JS -->
@@ -371,18 +372,7 @@
 
     observer.observe(document.querySelector('#load-more-trigger'));
     
-    
- 	// 위로 가는 버튼 제어
-    document.addEventListener('DOMContentLoaded', function () {
-    const scrollToTopIcon = document.querySelector('.scroll-to-top-icon');
-
-    scrollToTopIcon.addEventListener('click', function () {
-        window.scrollTo({
-            top: 0,
-            behavior: 'smooth'  // 부드러운 스크롤 효과
-        });
-    });
-});
+    // 하단만 아이콘을 클릭하면 움직일수있게 추가함(추가 예정) 아래에서 위까지 올라갈수있게 설정해야함
     </script>
 
 	

--- a/groupware/src/main/resources/templates/board/detail.html
+++ b/groupware/src/main/resources/templates/board/detail.html
@@ -46,11 +46,8 @@
 <div class="d-flex align-items-start" style="font-size: 1rem; white-space: nowrap;">
   <div>
     <div class="d-flex align-items-center">
-      <span>작성자: </span>
-      <span th:text="${board.member?.memberName ?: '익명'}" class="me-2"></span>
-      <button type="button" class="btn btn-outline-danger btn-sm" title="신고" style="padding: 0.15rem 0.5rem; height: 28px;">
-        <i class="bi bi-exclamation-triangle-fill"></i>
-      </button>
+<span>작성자: </span>
+<span th:text="'[' + ${board.member?.dept?.deptName ?: '부서'} + ']' + ${board.member?.memberName ?: '익명'}" class="me-2"></span>
     </div>
     <div><span>작성일: </span><span th:text="${#temporals.format(board.regDate, 'yyyy-MM-dd HH:mm')}">등록일</span></div>
     <div><span>조회수: </span><span th:text="${board.views}">0</span></div>
@@ -96,47 +93,28 @@
 
 
 
-<!-- 댓글 작성 영역 -->
-<div class="comment-write p-4 bg-white rounded-4 shadow-sm mb-4">
-    <label class="fw-bold fs-5 mb-3 d-block">💬 댓글 달기</label>
-    <th:block sec:authorize="isAuthenticated()">
-        <form th:action="@{/replies/{boardNo}/create(boardNo=${board.boardNo})}" method="POST" class="d-flex gap-2 align-items-stretch">
-            <textarea name="reply_content" placeholder="댓글을 입력하세요" required class="form-control" style="resize: none; height: 60px;"></textarea>
-            <button type="submit" class="btn btn-primary" style="min-width: 80px;">등록</button>
-            <input type="hidden" name="board_no" th:value="${board.boardNo}"/>
-            <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
-        </form>
-    </th:block>
-    <th:block sec:authorize="isAnonymous()">
-        <p class="text-muted">로그인 후 댓글을 작성할 수 있습니다.</p>
-    </th:block>
-</div>
-
-
 <!-- 댓글 + 대댓글 리스트 -->
 <div th:each="reply : ${replyList}" class="reply-item mb-3 p-3 border rounded-3">
     <div class="d-flex align-items-start mb-2">
-        <!-- 프로필 아이콘 -->
-        <div class="profile-icon rounded-circle bg-secondary text-white d-flex justify-content-center align-items-center me-3" style="width:40px; height:40px; font-size: 20px;">
-            <i class="bi bi-person"></i> <!-- Bootstrap Icons 사용 예 -->
-        </div>
+    
+		<!-- 프로필 아이콘 -->
+		<div class="profile-icon rounded-circle bg-white text-white d-flex justify-content-center align-items-center me-3" style="width:40px; height:40px; font-size: 20px;">
+    		<img th:src="@{/img/default_profile.png}" alt="Profile Image" class="rounded-circle" style="width: 100%; height: 100%; object-fit: cover;">
+		</div>
         <div class="flex-grow-1">
             <div class="d-flex justify-content-between align-items-center">
                 <div>
-                    <strong th:text="${reply.memberName}">작성자</strong>
-                    <small class="text-muted ms-2" th:text="${reply.timeAgo}"></small> <!--일단 아직 보류(팀원들은 년도 날짜식으로 바꿧으면 좋겠다고 했고, 선생님은 알아서 생각해서 했으면 좋겠다고 해서 좀 생각해보기)  -->
+                 <!-- 댓글 작성자 -->
+					<strong th:text="'[' + ${reply.deptName != null ? reply.deptName : '부서없음'} + '] ' + ${reply.memberName != null ? reply.memberName : '익명'}" class="me-2"></strong>
+                    <small class="ms-2" th:text="${reply.regDateFormatted}" style="color: black;">댓글 등록 시간</small>
                 </div>
+                
                 <th:block th:if="${reply.member_no == #authentication.principal.member.memberNo}">
                     <div class="reply-actions d-flex gap-2">
                         <button type="button" class="btn btn-primary btn-sm" th:onclick="|replyUpdate(${reply.reply_no})|">수정</button>
                         <button type="button" class="btn btn-danger btn-sm" th:onclick="|replyDelete(${reply.reply_no}, ${board.boardNo})|">삭제</button>
                     </div>
                 </th:block>
-                <th:block th:if="${reply.member_no != #authentication.principal.member.memberNo}">
-    				<button type="button" class="btn btn-outline-danger btn-sm" title="신고">
-        				<i class="bi bi-exclamation-triangle-fill"></i>
-    				</button>
-				</th:block>
             </div>
 
             <p class="reply-content mt-2 mb-2" th:id="'reply-content-' + ${reply.reply_no}" th:text="${reply.reply_content}"></p>
@@ -151,7 +129,7 @@
 
             <!-- 답글 버튼 -->
             <div class="mb-2">
-                <button type="button" class="btn btn-sm btn-primary" th:onclick="|showReplyForm(${reply.reply_no})|">댓글달기</button>
+                <button type="button" class="btn btn-sm btn-primary" th:onclick="|showReplyForm(${reply.reply_no})|">답글달기</button>
             </div>
 
             <!-- 대댓글 입력 폼 -->
@@ -168,14 +146,16 @@
             <div class="sub-reply-list ps-4 border-start" th:if="${reply.subReplies != null and !#lists.isEmpty(reply.subReplies)}">
                 <div th:each="subReply : ${reply.subReplies}" class="sub-reply-item py-2">
                     <div class="d-flex align-items-start">
-                        <div class="profile-icon rounded-circle bg-secondary text-white d-flex justify-content-center align-items-center me-3" style="width:30px; height:30px; font-size: 16px;">
-                            <i class="bi bi-person"></i>
-                        </div>
+					<!-- 프로필 아이콘 (아이콘 크기 30px) -->
+						<div class="profile-icon rounded-circle bg-white d-flex justify-content-center align-items-center me-3" style="width:30px; height:30px; font-size: 16px;">
+    						<img th:src="@{/img/default_profile.png}" alt="Profile Image" class="rounded-circle" style="width: 100%; height: 100%; object-fit: cover;">
+						</div>
                         <div class="flex-grow-1">
                             <div class="d-flex justify-content-between align-items-center">
                                 <div>
-                                    <strong th:text="${subReply.memberName}">작성자</strong>
-                                    <small class="text-muted ms-2" th:text="${subReply.timeAgo}"></small>
+								<!-- 대댓글 작성자 -->
+							<strong th:text="'[' + ${subReply.deptName != null ? subReply.deptName : '부서없음'} + '] ' + ${subReply.memberName != null ? subReply.memberName : '익명'}" class="me-2"></strong>
+                                    <small class="ms-2" th:text="${subReply.regDateFormatted}" style="color: black;">대댓글 등록 시간</small>
                                 </div>
                                 <th:block th:if="${subReply.member_no == #authentication.principal.member.memberNo}">
                                     <div class="reply-actions d-flex gap-2">
@@ -183,11 +163,6 @@
                                         <button type="button" class="btn btn-danger btn-sm" th:onclick="|replyDelete(${subReply.reply_no})|">삭제</button>
                                     </div>
                                 </th:block>
-                               <th:block th:if="${subReply.member_no != #authentication.principal.member.memberNo}">
-    								<button type="button" class="btn btn-outline-danger btn-sm" title="신고">
-        								<i class="bi bi-exclamation-triangle-fill"></i>
-    								</button>
-								</th:block>
                             </div>
                             <p class="reply-content mt-1 mb-1" th:id="'reply-content-' + ${subReply.reply_no}" th:text="${subReply.reply_content}"></p>
 
@@ -205,10 +180,22 @@
         </div>
     </div>
 </div>
- <!-- 댓글 리스트 반복문 끝난 후 -->
-<div class="scroll-to-top-wrapper text-center my-4">
-    <i class="bi bi-arrow-up-circle" style="font-size: 2rem; cursor: pointer;" title="맨 위로 이동"></i>
+
+<!-- 댓글 작성 영역 (하단 고정) -->
+<div class="comment-write p-4 bg-white rounded-4 shadow-sm mb-4 fixed-bottom">
+    <th:block sec:authorize="isAuthenticated()">
+        <form th:action="@{/replies/{boardNo}/create(boardNo=${board.boardNo})}" method="POST" class="d-flex gap-2 align-items-stretch">
+            <textarea name="reply_content" placeholder="댓글을 입력하세요" required class="form-control" style="resize: none; height: 60px;"></textarea>
+            <button type="submit" class="btn btn-primary" style="min-width: 80px;">등록</button>
+            <input type="hidden" name="board_no" th:value="${board.boardNo}"/>
+            <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
+        </form>
+    </th:block>
+    <th:block sec:authorize="isAnonymous()">
+        <p class="text-muted">로그인 후 댓글을 작성할 수 있습니다.</p>
+    </th:block>
 </div>
+
             
 <!-- 삭제 JS 및 대댓글 폼 표시 JS -->
     <script>
@@ -241,7 +228,7 @@
         	}
         
         
-        // 댓글 수정 기능
+     // 댓글 수정 기능
         function replyUpdate(replyNo) {
             const content = document.getElementById(`reply-content-${replyNo}`);
             const form = document.getElementById(`reply-edit-form-${replyNo}`);
@@ -291,6 +278,7 @@
                 form.style.display = 'block';
             }
         }
+
         // 댓글 취소 기능
         function cancelReplyEdit(replyNo) {
             // 수정 폼을 숨깁니다.
@@ -298,81 +286,97 @@
             // 원래 댓글 내용을 다시 보이도록 합니다.
             document.getElementById(`reply-content-${replyNo}`).style.display = 'block';
         }
-        
-          
-       // 댓글 삭제 기능
-         function replyDelete(replyNo) {
-  			if (!confirm("댓글을 삭제하시겠습니까?")) return;
-  			fetch(`/replies/${replyNo}/delete`, {
-    			method: 'POST',
-    			headers: {
-      		[csrfHeader]: csrfToken,  // CSRF 토큰 추가
-      		'Content-Type': 'application/json'
-    		}
-  		})
-  		.then(res => res.json())
-  		.then(data => {
-    		if (data.res_code === "200") {
-      			alert(data.res_msg);  // 댓글 삭제 성공 메시지
-      			location.reload();  // 페이지 새로 고침 (댓글 목록 갱신)
-    	} else {
-      			alert(data.res_msg);  // 댓글 삭제 실패 메시지
-    	}
-  	})
-  		.catch(err => {
-    		alert("에러 발생: " + err);  // 에러 처리
-  		});
-	}
 
-    const showEditReplyForm = (replyNo) => {
-        const replyForm = document.getElementById(`edit-reply-form-${replyNo}`);
-        if (replyForm !== null) {
-            // 수정 폼을 보이거나 숨기기
-            replyForm.style.display = (replyForm.style.display === 'none' || replyForm.style.display === '') ? 'block' : 'none';
-        }
-    };
-
-    const showReplyForm = (replyNo) => {
-        const replyForm = document.getElementById(`reply-form-${replyNo}`);
-        if (replyForm) {
-            replyForm.style.display = replyForm.style.display === 'none' ? 'block' : 'none';
-        }
-    };
-    
-    let page = 1;
-    const loadMoreComments = () => {
-        // 여기서 추가 댓글을 로드하는 API를 호출하세요.
-        page++;
-        fetch(`/comments?page=${page}`)
-            .then(response => response.json())
+        // 댓글 삭제 기능
+        function replyDelete(replyNo) {
+            if (!confirm("댓글을 삭제하시겠습니까?")) return;
+            fetch(`/replies/${replyNo}/delete`, {
+                method: 'POST',
+                headers: {
+                    [csrfHeader]: csrfToken,  // CSRF 토큰 추가
+                    'Content-Type': 'application/json'
+                }
+            })
+            .then(res => res.json())
             .then(data => {
-                // 로드된 댓글 데이터를 화면에 추가
-                const commentContainer = document.getElementById('comment-container');
-                data.comments.forEach(comment => {
-                    const commentElement = document.createElement('div');
-                    commentElement.classList.add('reply-item');
-                    commentElement.innerHTML = `
-                        <p>${comment.content}</p>
-                        <p>작성자: ${comment.memberName}</p>
-                    `;
-                    commentContainer.appendChild(commentElement);
-                });
+                if (data.res_code === "200") {
+                    alert(data.res_msg);  // 댓글 삭제 성공 메시지
+                    location.reload();  // 페이지 새로 고침 (댓글 목록 갱신)
+                } else {
+                    alert(data.res_msg);  // 댓글 삭제 실패 메시지
+                }
+            })
+            .catch(err => {
+                alert("에러 발생: " + err);  // 에러 처리
             });
-    };
+        }
 
-    const observer = new IntersectionObserver((entries, observer) => {
-        entries.forEach(entry => {
-            if (entry.isIntersecting) {
-                loadMoreComments();
+        const showEditReplyForm = (replyNo) => {
+            const replyForm = document.getElementById(`edit-reply-form-${replyNo}`);
+            if (replyForm !== null) {
+                // 수정 폼을 보이거나 숨기기
+                replyForm.style.display = (replyForm.style.display === 'none' || replyForm.style.display === '') ? 'block' : 'none';
             }
-        });
-    }, {
-        rootMargin: '100px',
-    });
+        };
 
-    observer.observe(document.querySelector('#load-more-trigger'));
-    
-    // 하단만 아이콘을 클릭하면 움직일수있게 추가함(추가 예정) 아래에서 위까지 올라갈수있게 설정해야함
+        const showReplyForm = (replyNo) => {
+            const replyForm = document.getElementById(`reply-form-${replyNo}`);
+            if (replyForm) {
+                replyForm.style.display = replyForm.style.display === 'none' ? 'block' : 'none';
+            }
+        };
+
+        let page = 1;
+        const loadMoreComments = () => {
+            // 여기서 추가 댓글을 로드하는 API를 호출하세요.
+            page++;
+            fetch(`/comments?page=${page}`)
+                .then(response => response.json())
+                .then(data => {
+                    // 로드된 댓글 데이터를 화면에 추가
+                    const commentContainer = document.getElementById('comment-container');
+                    data.comments.forEach(comment => {
+                        const commentElement = document.createElement('div');
+                        commentElement.classList.add('reply-item');
+                        commentElement.innerHTML = `
+                            <p>${comment.content}</p>
+                            <p>작성자: ${comment.memberName}</p>
+                        `;
+                        commentContainer.appendChild(commentElement);
+                    });
+                });
+        };
+
+        const observer = new IntersectionObserver((entries, observer) => {
+            entries.forEach(entry => {
+                if (entry.isIntersecting) {
+                    loadMoreComments();
+                }
+            });
+        }, {
+            rootMargin: '100px',
+        });
+
+        observer.observe(document.querySelector('#load-more-trigger'));
+
+        // 댓글 작성 영역이 고정되도록 하는 기능 추가
+        document.addEventListener("DOMContentLoaded", function () {
+            const commentContainer = document.getElementById('comment-container');
+            const commentWriteArea = document.querySelector('.comment-write');
+
+            // 페이지 로드 시, 댓글 목록이 많아지면 스크롤이 자동으로 댓글 영역에 맞춰 내려가도록 처리
+            const handleScroll = () => {
+                commentContainer.scrollTop = commentContainer.scrollHeight;
+            };
+
+            // 댓글 추가 후 스크롤을 맨 아래로 내리기
+            document.querySelector('form').addEventListener('submit', function () {
+                setTimeout(handleScroll, 300); // 댓글이 추가된 후 스크롤 처리
+            });
+
+            // 대댓글/댓글을 추가할 때마다 페이지가 아래로 내려가도록 추가
+            window.addEventListener("resize", handleScroll);  // 창 크기 변경 시에도 처리
+        });
     </script>
 
 	

--- a/groupware/src/main/resources/templates/board/list.html
+++ b/groupware/src/main/resources/templates/board/list.html
@@ -30,10 +30,10 @@
     <div class="d-flex align-items-center gap-2">
         <!-- 검색 타입 -->
        <select name="search_type" class="form-select w-auto bg-primary-subtle border-0" style="width: 120px;">
-    		<option th:value="1" th:selected="${searchDto.search_type == 1}">선택</option>
-    		<option th:value="2" th:selected="${searchDto.search_type == 2}">제목</option>
-    		<option th:value="3" th:selected="${searchDto.search_type == 3}">내용</option>
-    		<option th:value="4" th:selected="${searchDto.search_type == 4}">제목+내용</option>
+    		<option th:value="0" th:selected="${searchDto.search_type == 0}">선택</option>
+    		<option th:value="1" th:selected="${searchDto.search_type == 1}">제목</option>
+    		<option th:value="2" th:selected="${searchDto.search_type == 2}">내용</option>
+    		<option th:value="3" th:selected="${searchDto.search_type == 3}">제목+내용</option>
 	  </select>
 
         <!-- 검색창(고침) -->

--- a/groupware/src/main/resources/templates/board/list.html
+++ b/groupware/src/main/resources/templates/board/list.html
@@ -35,15 +35,18 @@
     		<option th:value="2" th:selected="${searchDto.search_type == 2}">내용</option>
     		<option th:value="3" th:selected="${searchDto.search_type == 3}">제목+내용</option>
 	  </select>
-
-        <!-- 검색창(고침) -->
-	 <div class="position-relative" style="max-width: 350px;">
-          <input type="text" name="search_text" th:value="${searchDto.search_text}"
-                 class="form-control search-chat py-2 ps-5" id="search_text" placeholder="Search Contact" />
-          <button type="submit" class="btn position-absolute top-50 start-0 translate-middle-y bg-transparent border-0 p-0 ms-3">
-            <i class="ti ti-search fs-6 text-dark"></i>
-          </button>
-   	</div>
+<!-- 검색창 옆에 X표시로 만든 이유는 검색어를 입력하면 원래대로 돌아갈수가없어서 X표시 추가하고 초기화 해주면서 다시 목록으로 돌아갈수있게 코드 추가 -->
+<div class="position-relative" style="max-width: 350px;">
+    <input type="text" name="search_text" th:value="${searchDto.search_text}"
+           class="form-control search-chat py-2 ps-5" id="search_text" placeholder="검색어를 입력하세요." />
+    <button type="submit" class="btn position-absolute top-50 start-0 translate-middle-y bg-transparent border-0 p-0 ms-3">
+        <i class="ti ti-search fs-6 text-dark"></i>
+    </button>
+    <!-- 초기화 버튼 추가 -->
+    <button type="button" class="btn position-absolute top-50 start-100 translate-middle-y bg-transparent border-0 p-0 ms-3" onclick="resetSearch()">
+        <i class="ti ti-x fs-6 text-dark"></i>
+    </button>
+</div>
 </div>
 
     <!-- 오른쪽: 정렬 드롭다운 -->
@@ -82,18 +85,18 @@
             </thead>
           <tbody>
           
-          <!-- 게시글 목록에서 게시글이 없을경우 게시글이 없습니다라는 글을 달아줌 -->
-    <th:block th:if="${#lists.isEmpty(boardList)}">
-    	<tr>
-      		<td colspan="6" class="text-center text-muted">게시글이 없습니다.</td>
-    	</tr>
-  	</th:block>
+<!-- 게시글이 없을 경우, 고정글과 일반글이 모두 없을 때만 "게시글이 없습니다" 문구가 보이게 처리 -->
+<th:block th:if="${#lists.isEmpty(boardList) and #lists.isEmpty(fixedList)}">
+    <tr>
+        <td colspan="6" class="text-center text-muted">게시글이 없습니다.</td>
+    </tr>
+</th:block>
           
 <!-- 고정글 목록 출력 -->
 <tr th:each="board : ${fixedList}" 
     th:data-board-no="${board.boardNo}"
     th:onclick="|window.location.href='/board/detail/' + ${board.boardNo}|"
-    class="fixed-row">
+    class="fixed-row" style="cursor:pointer;">
     <td><span>📌</span></td>
     <td class="text-center"><span th:text="${board.boardTitle}">제목</span></td>
     <td th:text="${board.member.memberName}">작성자</td>
@@ -107,7 +110,9 @@
     th:data-board-no="${board.boardNo}"
     th:onclick="|window.location.href='/board/detail/' + ${board.boardNo}|"
     style="cursor:pointer;">
-    <td th:text="${(searchDto.order_type == 1) ? (pageDto.totalPage - pageDto.nowPage) * pageDto.numPerPage + (pageDto.numPerPage - stat.index) : (pageDto.nowPage - 1) * pageDto.numPerPage + stat.index + 1}">번호</td>
+<td th:text="${(searchDto.order_type == 1) ? 
+    (pageDto.totalCount - ((pageDto.nowPage - 1) * pageDto.numPerPage + stat.index)) 
+    : ((pageDto.nowPage - 1) * pageDto.numPerPage + stat.index + 1)}">번호</td>
     <td class="text-center" th:text="${board.boardTitle}">제목</td>
     <td th:text="${board.member.memberName}">작성자</td>
     <td th:text="${#temporals.format(board.regDate, 'yyyy/MM/dd HH:mm')}">등록일</td>
@@ -167,6 +172,14 @@
   </th:block>
 
 </div>
+
+	<script>
+    // 검색어 초기화 함수
+    function resetSearch() {
+        document.getElementById('search_text').value = ''; // 검색어 입력 필드 초기화
+        window.location.href = window.location.pathname; // 페이지 새로고침
+    }
+	</script>
 
     <!-- Bootstrap Common JS Files Start -->
     <script th:src="@{/assets/js/vendor.min.js}"></script>

--- a/groupware/src/main/resources/templates/board/update.html
+++ b/groupware/src/main/resources/templates/board/update.html
@@ -20,9 +20,7 @@
         <nav aria-label="breadcrumb">
             <ol class="breadcrumb align-items-center">
                 <li class="breadcrumb-item">
-                    <a class="text-muted text-decoration-none" th:href="@{/home}">
-                        <i class="ti ti-home fs-5"></i>
-                    </a>
+                    <a class="text-muted text-decoration-none" th:href="@{/home}"><i class="ti ti-home fs-5"></i></a>
                 </li>
                 <li class="breadcrumb-item active" aria-current="page">자유게시판 수정</li>
             </ol>
@@ -39,26 +37,34 @@
             <input type="hidden" name="board_content" id="board_content"/>
             <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
 
-		<!-- 제목 + 투표 버튼 (한 줄에 정렬) -->
-		<div class="d-flex align-items-center mb-3">
-  			<!-- 왼쪽: 제목 입력 -->
-  		<div class="d-flex align-items-center flex-grow-1">
-    		<span class="fw-bold me-3" style="font-size: 1rem; line-height: 1; white-space: nowrap;">
-      					제목
-    		</span>
-    	<input type="text" class="form-control bg-white text-dark"
-           	id="board_title" name="board_title"
-           	th:value="${board.boardTitle}"
-           	maxlength="100" placeholder="제목을 입력하세요" required>
-  		</div>
+            <!-- 게시글 상단 고정 체크박스 -->
+            <div class="form-check mb-3">
+                <input class="form-check-input" type="checkbox" id="is_fixed" name="is_fixed" value="true"
+                       th:checked="${board.isFixed != null and board.isFixed}"/>
+                <label class="form-check-label" for="is_fixed">
+                    게시글 상단에 고정
+                </label>
+            </div>
 
-  		<!-- 오른쪽: 투표 버튼 -->
-  		<div class="ms-3">
-    		<button type="button" class="btn btn-outline-danger" onclick="openVoteModal()">
-      		투표 삭제
-    		</button>
-  		</div>
-		</div>
+            <!-- 제목 + 투표 버튼 (한 줄에 정렬) -->
+            <div class="d-flex align-items-center mb-3">
+                <div class="d-flex align-items-center flex-grow-1">
+                    <span class="fw-bold me-3" style="font-size: 1rem; line-height: 1; white-space: nowrap;">
+                        제목
+                    </span>
+                    <input type="text" class="form-control bg-white text-dark"
+                           id="board_title" name="board_title"
+                           th:value="${board.boardTitle}"
+                           maxlength="100" placeholder="제목을 입력하세요" required>
+                </div>
+
+                <!-- 오른쪽: 투표 버튼 -->
+                <div class="ms-3">
+                    <button type="button" class="btn btn-outline-danger" onclick="openVoteModal()">
+                        투표 삭제
+                    </button>
+                </div>
+            </div>
 
             <!-- 내용 -->
             <div class="mb-3">
@@ -96,103 +102,88 @@
     <!-- Toast UI Editor -->
     <script src="https://uicdn.toast.com/editor/latest/toastui-editor-all.min.js"></script>
 
-<script th:inline="javascript">
-    const initialContent = /*[[${board.boardContent}]]*/ '';
-    const boardNo = /*[[${board.boardNo}]]*/ 0;
-</script>
+    <script th:inline="javascript">
+        const initialContent = /*[[${board.boardContent}]]*/ '';
+        const boardNo = /*[[${board.boardNo}]]*/ 0;
+    </script>
 
-<script>
-    document.addEventListener("DOMContentLoaded", function () {
-        const editor = new toastui.Editor({
-            el: document.querySelector('#editor'),
-            height: '400px',
-            initialEditType: 'wysiwyg',
-            previewStyle: 'vertical',
-            initialValue: initialContent
-        });
-
-        const form = document.getElementById("board_form");
-
-        form.addEventListener("submit", function (e) {
-            e.preventDefault();
-
-            const title = form.board_title.value.trim();
-            const content = editor.getHTML();
-            document.getElementById("board_content").value = content;
-
-            let msg = "";
-            if (!title) msg += "제목을 입력하세요.\n";
-            if (!content || content === '<p><br></p>') msg += "내용을 입력하세요.\n";
-
-            if (msg) {
-                alert(msg);
-                return;
-            }
-
-            const payload = new FormData(form);
-
-            // CSRF 처리
-            const csrfToken = document.querySelector('meta[name="_csrf"]').content;
-            const csrfHeader = document.querySelector('meta[name="_csrf_header"]').content;
-
-            // 삭제할 파일 정보 추가
-            document.querySelectorAll("input[name='deleteFiles']").forEach(hidden => {
-                if (!hidden.disabled) {
-                    payload.append("deleteFiles", hidden.value);
-                }
+    <script>
+        document.addEventListener("DOMContentLoaded", function () {
+            const editor = new toastui.Editor({
+                el: document.querySelector('#editor'),
+                height: '400px',
+                initialEditType: 'wysiwyg',
+                previewStyle: 'vertical',
+                initialValue: initialContent
             });
 
-            // fetch 요청 (게시글 수정 처리)
-            fetch("/board/" + boardNo + "/update", {
-                method: "POST",
-                headers: {
-                    [csrfHeader]: csrfToken
-                },
-                body: payload
-            })
-            .then(res => {
-                if (!res.ok) {
-                    throw new Error("서버 응답 오류");
+            const form = document.getElementById("board_form");
+
+            form.addEventListener("submit", function (e) {
+                e.preventDefault();
+
+                const title = form.board_title.value.trim();
+                const content = editor.getHTML();
+                document.getElementById("board_content").value = content;
+
+                let msg = "";
+                if (!title) msg += "제목을 입력하세요.\n";
+                if (!content || content === '<p><br></p>') msg += "내용을 입력하세요.\n";
+
+                if (msg) {
+                    alert(msg);
+                    return;
                 }
-                return res.json();
-            })
-            .then(data => {
-                alert(data.res_msg);
-                if (data.res_code === "200") {
-                    // 상세페이지 이동
-                    location.href = "/board/detail/" + data.boardNo;
-                }
-            })
-            .catch(err => {
-                console.error(err);
-                alert("수정 중 오류가 발생했습니다.");
+
+                const payload = new FormData(form);
+
+                // CSRF 처리
+                const csrfToken = document.querySelector('meta[name="_csrf"]').content;
+                const csrfHeader = document.querySelector('meta[name="_csrf_header"]').content;
+
+                // 삭제할 파일 정보 추가
+                document.querySelectorAll("input[name='deleteFiles']").forEach(hidden => {
+                    if (!hidden.disabled) {
+                        payload.append("deleteFiles", hidden.value);
+                    }
+                });
+
+                // fetch 요청 (게시글 수정 처리)
+                fetch("/board/" + boardNo + "/update", {
+                    method: "POST",
+                    headers: {
+                        [csrfHeader]: csrfToken
+                    },
+                    body: payload
+                })
+                .then(response => response.json())
+                .then(data => {
+                    alert(data.res_msg);
+                    if (data.res_code === '200') {
+                        location.href = "/board/list";
+                    }
+                })
+                .catch(error => {
+                    console.error(error);
+                    alert("서버 오류가 발생했습니다.");
+                });
             });
         });
-
-        // 체크박스 누르면 삭제 표시
-        window.toggleDeleteCheckbox = function (checkbox) {
+        // 체크가 해제될 때 삭제 처리
+        function toggleDeleteCheckbox(checkbox) {
             const item = checkbox.closest('.file-item');
             const hidden = item.querySelector('input[type=hidden]');
             const filename = item.querySelector('.file-name');
 
             if (!checkbox.checked) {
                 hidden.disabled = false;
-                filename.classList.add('text-decoration-line-through');
+                filename.classList.add('text-decoration-line-through'); // 밑줄 추가
             } else {
                 hidden.disabled = true;
-                filename.classList.remove('text-decoration-line-through');
+                filename.classList.remove('text-decoration-line-through'); // 밑줄 제거
             }
-        };
-
-        // 투표 모달 (임시)
-        window.openVoteModal = function () {
-            alert("투표 모달 띄우기 기능은 구현 예정입니다.");
-        };
-    });
-</script>
-
-
-  	<script th:src="@{/assets/js/vendor.min.js}"></script>
+        }
+    </script>
 
     <!-- Bootstrap Common JS Files Start -->
     <script th:src="@{/assets/js/vendor.min.js}"></script>


### PR DESCRIPTION
댓글/대댓글 = 몇분전 X -> yyyy-MM-dd HH:mm으로 수정
게시글 목록 = 고정글 tr -> 마우스 포인터 수정
댓글창을 아래에 배치 고정시킴(한번 보시고, 피드백할게 있으시면 얘기 부탁드려요) - 정확하진 않아서 테스트 해보시고 얘기해주세요.
자유게시판 목록 = 최신순 역순으로 하는데 10부터 나오는거 고쳤습니다(테스트 해보시면 2개가 있다면 2,1 이런식으로 나올꺼에요.)
게시글 작성에서 고정글 체크를 하고 만들면 목록에서 체크되고, 수정 페이지에 들어가면 고정글 체크가 되어있고 해제를 하고 수정을 하면 일반글로 바꾸게 수정했습니다.
게시글 목록에서 고정글만 삭제가 안됐는데 삭제되서 목록에서 나오지 않게 만들었습니다.
게시판 목록에서 아무것도 없을때 게시글이 없습니다라는 문구가 나오는데, 근데 일반글을 생성하면 없어지는걸로 바꿨는데,
고정글도 똑같이 생성을 하면 게시글이 없습니다라는 문구가 없어지게 구현했음(일반글은 목록에 추가하면 페이징이 되는데 고정글은 페이징이 안되게 했습니다.)
댓글/대댓글에서 작성자([부서명]성명) 수정 완료(게시글 상세도 그렇게 바꿨습니다.)
게시글 수정에서 파일이 밑줄긋기가 없어져서 다시 수정
댓글/대댓글 임시로 기본 프로필 넣어줌(전에는 아이콘으로 대체했는데 바꿈) -> 이후에 다시 프로필을 넣어준다면 바뀌게 만들예정입니다.

자기전에 안되는 기능 정리
댓글에서 답글 달기(대댓글) 대댓글이 많아질수있어서 (예시:답글3개 이런식으로 표시)답글 확인할수있게 만드는거 /
검색필터를 써서 검책창에 제목,내용,제목+내용 입력해서 찾으면 고정글이 딸려오는데 그걸 없어주는 작업을 해야함
테스트 해보시고 맘에 안드는 부분이나 추가를 더 해야할 부분있으면 재익 팀장님이 얘기해주시면 최대한 반영해서 고쳐서 다시 올리겠습니다.